### PR TITLE
make AudioFX optional

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -84,7 +84,9 @@ endif
 
 # XenonHD packages
 PRODUCT_PACKAGES += \
+ifneq ($(DISABLE_AUDIOFX), true)
     AudioFX \
+endif
     BluetoothExt \
     CMAudioService \
     CMParts \


### PR DESCRIPTION
by default it's included, but I hate this app bcz it crashes even on CM on my device